### PR TITLE
use live camera-info messages to obtain intrinsic parameters

### DIFF
--- a/charuco_detector/src/charuco_detector.cpp
+++ b/charuco_detector/src/charuco_detector.cpp
@@ -198,6 +198,8 @@ void ChArUcoDetector::getCameraCalibrationCoefficient() {
     	std::cout << "Can't load 'camera_calibration.ini'\n";
     	return;
 	}
+	camera_intrinsics_matrix.release();
+	camera_distortion_coefficients_matrix.release();
 	camera_intrinsics_matrix = cv::Mat::zeros(3, 3, CV_64F);
 	camera_distortion_coefficients_matrix = cv::Mat::zeros(1, 5, CV_64F);
 
@@ -233,18 +235,20 @@ void ChArUcoDetector::cameraInfoCallback(const sensor_msgs::msg::CameraInfo::Con
 		}
 	}
 	if (valid_camera_info) {
-		getCameraCalibrationCoefficient();
+		//getCameraCalibrationCoefficient();
 		camera_info_ = _msg;
-		// camera_intrinsics_matrix = cv::Mat::zeros(3, 3, CV_64F);
-		// camera_distortion_coefficients_matrix = cv::Mat::zeros(1, 5, CV_64F);
-		// for (int i = 0; i < 3; i++) {
-		// 	for (int j = 0; j < 3; j++) {
-		// 		camera_intrinsics_matrix.at<double>(i, j) = _msg->K[i * 3 + j];
-		// 	}
-		// }
-		// for (int i = 0; i < 5; i++) {
-		// 	camera_distortion_coefficients_matrix.at<double>(0, i) = _msg->D[i];
-		// }
+		camera_intrinsics_matrix.release();
+		camera_distortion_coefficients_matrix.release();
+		camera_intrinsics_matrix = cv::Mat::zeros(3, 3, CV_64F);
+		camera_distortion_coefficients_matrix = cv::Mat::zeros(1, 5, CV_64F);
+		for (int i = 0; i < 3; i++) {
+			for (int j = 0; j < 3; j++) {
+				camera_intrinsics_matrix.at<double>(i, j) = _msg->k[i * 3 + j];
+			}
+		}
+		for (int i = 0; i < 5; i++) {
+			camera_distortion_coefficients_matrix.at<double>(0, i) = _msg->d[i];
+		}
 	} else {
 		RCLCPP_WARN(get_logger(),"Received invalid camera intrinsics (K all zeros)");
 	}


### PR DESCRIPTION
…and avoid memory leaks. there were some small bugs in the commented code.